### PR TITLE
closes #61, #66 twitter login

### DIFF
--- a/css/myStyle.css
+++ b/css/myStyle.css
@@ -122,3 +122,6 @@ body {
 footer {
   text-align: center;
 }
+#login {
+  cursor: pointer;
+}

--- a/index.html
+++ b/index.html
@@ -37,7 +37,7 @@
     <div id="fridge" class="brushed-metal"> </div>
     <footer>
       <div id="shareLink">Share</div>
-
+      <img id="login" src="//si0.twimg.com/images/dev/buttons/sign-in-with-twitter-d.png" alt="Sign in with Twitter" />
     </footer>
   </div> <!--! end of #container -->
 

--- a/js/magpo.js
+++ b/js/magpo.js
@@ -413,6 +413,51 @@
     }
   });
 
+  /**
+   * Defines the login view.
+   */
+  var LoginView = Backbone.View.extend({
+    el: $('#login'),
+    events: {
+      'click': 'login',
+    },
+    login: function(e) {
+      var self = this;
+      // Save the poem if it hasn't been saved yet so we have a valid
+      // return URL.
+      if (
+        (typeof window.MagPo.app.poem.id === 'undefined' ||
+          window.MagPo.app.poem.id === null
+        ) &&
+        window.MagPo.app.poem.words.length
+      ) {
+        window.MagPo.app.poem.save();
+        window.MagPo.app.poem.on('saved', function() {
+          self._login();
+          window.MagPo.app.poem.off('saved');
+        });
+      }
+      else {
+        self._login();
+      }
+    },
+    _login: function() {
+      // First, get a request token.
+      $.ajax({
+        url: 'app/login',
+        contentType: 'application/json',
+        data: JSON.stringify({
+          success: window.location.toString(),
+        }),
+        dataType: 'json',
+        type: 'POST',
+        success: function(data) {
+          
+        }
+      });
+    }
+  });
+
   window.JST = {};
 
   window.JST['twitterLink'] = _.template(
@@ -554,6 +599,9 @@
       };
       self.drawers[drawer.id] = drawerObj;
     });
+
+    self.login = new LoginView();
+    self.login.render();
 
     self.router = null;
   };

--- a/js/magpo.js
+++ b/js/magpo.js
@@ -632,8 +632,11 @@
     var tUser = localStorage.getItem('MagPo_tUser');
     var user = localStorage.getItem('MagPo_user');
     if (oauth_token.length && oauth_verifier.length && tUser) {
-      // TODO - remove the OAuth query arguments.
-      // @see history.pushState().
+      // Remove the query arguments.
+      // TODO - detect a hash.
+      history.pushState({}, '', '/magpo/');
+
+      // Send the login information to the back end.
       body = {
         oauth_token: oauth_token,
         oauth_verifier: oauth_verifier,

--- a/js/magpo.js
+++ b/js/magpo.js
@@ -452,7 +452,7 @@
         dataType: 'json',
         type: 'POST',
         success: function(data) {
-          
+          // TODO - redirect to data.Location
         }
       });
     }

--- a/js/package.json
+++ b/js/package.json
@@ -7,6 +7,7 @@
   "flatiron": "0.1.11",
   "mongoose": "2.5.5",
   "node-uuid": "1.3.3",
+  "oauth": "0.9.6",
   "underscore": "1.3.1",
   "union": "0.1.7"
  },

--- a/js/package.json
+++ b/js/package.json
@@ -7,7 +7,6 @@
   "flatiron": "0.1.11",
   "mongoose": "2.5.5",
   "node-uuid": "1.3.3",
-  "ntwitter": "0.2.10",
   "underscore": "1.3.1",
   "union": "0.1.7"
  },

--- a/js/package.json
+++ b/js/package.json
@@ -7,6 +7,7 @@
   "flatiron": "0.1.11",
   "mongoose": "2.5.5",
   "node-uuid": "1.3.3",
+  "ntwitter": "0.2.10",
   "underscore": "1.3.1",
   "union": "0.1.7"
  },

--- a/js/server/app.js
+++ b/js/server/app.js
@@ -13,6 +13,7 @@ var headers = {
 
 app.use(flatiron.plugins.http);
 app.use(require('./plugins/magpo'));
+app.use(require('./plugins/twitter'));
 
 app.init(function(err) {
   if (err) {
@@ -25,32 +26,41 @@ app.init(function(err) {
  */
 app.router.get('/', function() {
   this.res.writeHead(200, headers);
-  this.res.end(JSON.stringify({ status: 'ok' }));
+  this.res.json({ status: 'ok' });
 });
 
 app.router.get('/save', function() {
   this.res.writeHead(400, headers);
-  this.res.end(JSON.stringify({
+  this.res.json({
     status: 'error',
     error: 'Only POST requests are accepted.'
-  }));
+  });
 });
 
 /**
  * POST routes.
  */
+app.router.post('/login', function() {
+  var self = this;
+  if (typeof self.req.body.success === 'undefined') {
+    self.res.writeHead(400, headers);
+    self.res.json({ status: 'error', error: 'Missing success URL.' });
+  }
+  app.login(self.req, self.res, self.req.body.success);
+});
+
 app.router.post('/load/:id', function(id) {
   var self = this;
   app.loadPoem(id, function onLoad(err, doc) {
     if (err) {
       console.error(err);
       self.res.writeHead(500, headers);
-      self.res.end(JSON.stringify({ status: 'error', error: 'Error loading poem.' }));
+      self.res.json({ status: 'error', error: 'Error loading poem.' });
       return;
     }
     if (doc == null) {
       self.res.writeHead(404, headers);
-      self.res.end(JSON.stringify({ status: 'error', error: 'Poem not found.' }));
+      self.res.json({ status: 'error', error: 'Poem not found.' });
       return;
     }
 
@@ -65,7 +75,7 @@ app.router.post('/load/:id', function(id) {
     delete doc._doc.author;
 
     self.res.writeHead(200, headers);
-    self.res.end(JSON.stringify({ status: 'ok', poem: doc, author: author }));
+    self.res.json({ status: 'ok', poem: doc, author: author });
   });
 });
 
@@ -94,24 +104,25 @@ app.router.post('/save', function() {
       redirect = false;
     }
     self.res.writeHead(200, headers);
-    self.res.end(JSON.stringify({
+    self.res.json({
       status: 'ok',
       poem: poem,
       redirect: redirect
-    }));
+    });
   });
 });
+
 app.router.post('/remove/:id', function(id) {
   var self = this;
   app.removePoem(id, function onRemoved(err) {
     if (err) {
       console.error(err);
       self.res.writeHead(500, headers);
-      self.res.end(JSON.stringify({ status: 'error', error: 'Error removing poem.' }));
+      self.res.json({ status: 'error', error: 'Error removing poem.' });
       return;
     }
     self.res.writeHead(200, headers);
-    self.res.end(JSON.stringify({ status: 'ok' }));
+    self.res.json({ status: 'ok' });
   });
 });
 

--- a/js/server/app.js
+++ b/js/server/app.js
@@ -120,13 +120,30 @@ app.router.post('/remove/:id', function(id) {
   var self = this;
   app.removePoem(id, function onRemoved(err) {
     if (err) {
-      console.error(err);
       self.res.writeHead(500, headers);
       self.res.json({ status: 'error', error: 'Error removing poem.' });
       return;
     }
     self.res.writeHead(200, headers);
     self.res.json({ status: 'ok' });
+  });
+});
+
+app.router.post('/update/:id', function(id) {
+  var self = this;
+  if (typeof self.req.body.oldAuthor === 'undefined' || typeof self.req.body.newAuthor === 'undefined') {
+    self.res.writeHead(400);
+    self.res.end();
+    return;
+  }
+  app.updatePoemAuthor(id, self.req.body.oldAuthor, self.req.body.newAuthor, function(err) {
+    if (err) {
+      self.res.writeHead(500);
+      self.res.end();
+      return;
+    }
+    self.res.writeHead(200);
+    self.res.end();
   });
 });
 

--- a/js/server/app.js
+++ b/js/server/app.js
@@ -49,6 +49,10 @@ app.router.post('/login', function() {
   app.login(self.req, self.res, self.req.body.success);
 });
 
+app.router.post('/login-verify', function() {
+  app.loginVerify(this.req, this.res);
+});
+
 app.router.post('/load/:id', function(id) {
   var self = this;
   app.loadPoem(id, function onLoad(err, doc) {

--- a/js/server/example.local.js
+++ b/js/server/example.local.js
@@ -11,4 +11,10 @@ module.exports = {
     user: 'admin',
     password: 'admin',
   },
+  twitter: {
+    consumer_key: 'xxx',
+    consumer_secret: 'xxx',
+    access_token_key: 'xxx',
+    access_token_secret: 'xxx',
+  },
 };

--- a/js/server/example.local.js
+++ b/js/server/example.local.js
@@ -12,6 +12,9 @@ module.exports = {
     password: 'admin',
   },
   twitter: {
+    access_url: 'https://api.twitter.com/oauth/access_token',
+    authorize_url: 'https://api.twitter.com/oauth/authorize',
+    request_token_url: 'https://api.twitter.com/oauth/request_token',
     consumer_key: 'xxx',
     consumer_secret: 'xxx',
     access_token_key: 'xxx',

--- a/js/server/models/user.js
+++ b/js/server/models/user.js
@@ -4,12 +4,18 @@
 
 var mongoose = require('mongoose');
 
+var TUserSchema = new mongoose.Schema({
+  oauth_token: String,
+  oauth_token_secret: String,
+});
+
 var UserSchema = new mongoose.Schema({
   user_id: String,
   screen_name: String,
-  oauth_token: String,
-  oauth_token_secret: String,
+  access_token: String,
+  access_token_secret: String,
   oauth_verifier: String,
 });
 
+exports.TUserModel = mongoose.model('TUser', TUserSchema);
 exports.UserModel = mongoose.model('User', UserSchema);

--- a/js/server/models/user.js
+++ b/js/server/models/user.js
@@ -1,0 +1,15 @@
+/**
+ * @fileoverview User model definition.
+ */
+
+var mongoose = require('mongoose');
+
+var UserSchema = new mongoose.Schema({
+  user_id: String,
+  screen_name: String,
+  oauth_token: String,
+  oauth_token_secret: String,
+  oauth_verifier: String,
+});
+
+exports.UserModel = mongoose.model('User', UserSchema);

--- a/js/server/plugins/magpo.js
+++ b/js/server/plugins/magpo.js
@@ -243,6 +243,32 @@ MagPo.attach = function() {
   this.removePoem = function(id, callback) {
     this.PoemModel.remove({ _id: id }, callback);
   };
+
+  /**
+   * Updates a poem's author.
+   *
+   * @param {string} id
+   *   The poem ID to update.
+   * @param {string} oldAuthor
+   *   The old author.
+   * @param {string} newAuthor
+   *   The new author.
+   * @param {function} callback
+   *   The callback function to execute on completion.
+   */
+  this.updatePoemAuthor = function(id, oldAuthor, newAuthor, callback) {
+    this.PoemModel.update(
+      { _id: id, author: oldAuthor },
+      { $set: { author: newAuthor } },
+      function(err, numChanged) {
+        if (err) {
+          console.error(err);
+        }
+        callback(err);
+      }
+    );
+  };
+
 };
 
 MagPo.init = function(done) {

--- a/js/server/plugins/twitter.js
+++ b/js/server/plugins/twitter.js
@@ -125,7 +125,7 @@ Twitter.attach = function(options) {
               }
               res.json({
                 status: 'ok',
-                id: results.user_id,
+                id: oauth_access_token,
                 screen_name: results.screen_name
               });
             }

--- a/js/server/plugins/twitter.js
+++ b/js/server/plugins/twitter.js
@@ -2,9 +2,12 @@
  * @fileoverview Handles MagPo-twitter integration.
  */
 
+var crypto = require('crypto');
+var http = require('http');
+var oauth = require('oauth');
 var settings = require('../local');
-var twitter = require('ntwitter');
 var url = require('url');
+var util = require('util');
 
 var Twitter = exports;
 
@@ -12,13 +15,29 @@ Twitter.attach = function(options) {
   /**
    * Logs a user into twitter.
    */
-  this.login = function(req, res, success) {
-    var handler = this.twitter.login('/login', success);
-    handler(req, res, function(err) {
-      if (err) {
-        res.writeHead(err);
+  this.login = function(Req, res, success) {
+    var self = this;
+
+    var oa = new oauth.OAuth(
+      self.twitter.request_token_url,
+      self.twitter.access_url,
+      self.twitter.consumer_key,
+      self.twitter.consumer_secret,
+      "1.0",
+      success,
+      'HMAC-SHA1'
+    );
+
+    var token = oa.getOAuthRequestToken(function(error, oauth_token, oauth_token_secret, results) {
+      if (error) {
+        console.error(util.format('Error %d: %s', error.statusCode, error.data));
+        res.writeHead(error.statusCode);
         res.end();
+        return;
       }
+
+      res.json(
+  { 'Location': 'https://api.twitter.com/oauth/authenticate?oauth_token=' + oauth_token });
       res.end();
     });
   };
@@ -26,12 +45,15 @@ Twitter.attach = function(options) {
 };
 
 Twitter.init = function(done) {
-  this.twitter = new twitter({
+  this.twitter = {
+    access_url: settings.twitter.access_url,
+    authorize_url: settings.twitter.authorize_url,
+    request_token_url: settings.twitter.request_token_url,
     consumer_key: settings.twitter.consumer_key,
     consumer_secret: settings.twitter.consumer_secret,
     access_token_key: settings.twitter.access_token_key,
     access_token_secret: settings.twitter.access_token_secret,
-  });
+  };
   return done();
 };
 

--- a/js/server/plugins/twitter.js
+++ b/js/server/plugins/twitter.js
@@ -8,6 +8,8 @@ var oauth = require('oauth');
 var settings = require('../local');
 var url = require('url');
 var util = require('util');
+var mongoose = require('mongoose');
+var User = require('../models/user').UserModel;
 
 var Twitter = exports;
 
@@ -15,7 +17,7 @@ Twitter.attach = function(options) {
   /**
    * Logs a user into twitter.
    */
-  this.login = function(Req, res, success) {
+  this.login = function(req, res, success) {
     var self = this;
 
     var oa = new oauth.OAuth(
@@ -36,9 +38,81 @@ Twitter.attach = function(options) {
         return;
       }
 
-      res.json(
-  { 'Location': 'https://api.twitter.com/oauth/authenticate?oauth_token=' + oauth_token });
+      var user = new User();
+      user.oauth_token = oauth_token;
+      user.oauth_token_secret = oauth_token_secret;
+      user.save(function(err) {
+        if (err) {
+          res.writeHead(500);
+          res.end();
+          return;
+        }
+        res.json({
+          'location': 'https://api.twitter.com/oauth/authenticate?oauth_token=' + oauth_token,
+          'user': user._id
+        });
+        res.end();
+      });
+    });
+  };
+
+  /**
+   * Verifies a login attempt against Twitter.
+   */
+  this.loginVerify = function(req, res) {
+    var self = this;
+    if (typeof req.body.user === 'undefined') {
+      res.writeHead(401);
       res.end();
+      return;
+    }
+    User.findOne({ _id: req.body.user }, function(err, doc) {
+      if (err || doc.oauth_token != req.body.oauth_token) {
+        console.error(err);
+        res.writeHead(401);
+        res.end();
+        return;
+      }
+
+      var oa = new oauth.OAuth(
+        self.twitter.request_token_url,
+        self.twitter.access_url,
+        self.twitter.consumer_key,
+        self.twitter.consumer_secret,
+        "1.0",
+        null,
+        'HMAC-SHA1'
+      );
+      var token = oa.getOAuthAccessToken(
+        doc.oauth_token,
+        doc.oauth_token_secret,
+        req.body.oauth_verifier,
+        function(err, oauth_access_token, oauth_access_token_secret, results) {
+          if (err) {
+            res.writeHead(401);
+            res.end();
+            return;
+          }
+
+          User.update(
+            { _id: doc._id },
+            { $set: {
+              user_id: results.user_id,
+              screen_name: results.screen_name
+            }},
+            {},
+            function(err, count) {
+              if (err) {
+                console.error(err);
+                res.writeHead(401);
+                res.end();
+                return;
+              }
+              res.json({ status: 'ok', screen_name: results.screen_name });
+            }
+          );
+        }
+      );
     });
   };
 

--- a/js/server/plugins/twitter.js
+++ b/js/server/plugins/twitter.js
@@ -1,0 +1,37 @@
+/**
+ * @fileoverview Handles MagPo-twitter integration.
+ */
+
+var settings = require('../local');
+var twitter = require('ntwitter');
+var url = require('url');
+
+var Twitter = exports;
+
+Twitter.attach = function(options) {
+  /**
+   * Logs a user into twitter.
+   */
+  this.login = function(req, res, success) {
+    var handler = this.twitter.login('/login', success);
+    handler(req, res, function(err) {
+      if (err) {
+        res.writeHead(err);
+        res.end();
+      }
+      res.end();
+    });
+  };
+
+};
+
+Twitter.init = function(done) {
+  this.twitter = new twitter({
+    consumer_key: settings.twitter.consumer_key,
+    consumer_secret: settings.twitter.consumer_secret,
+    access_token_key: settings.twitter.access_token_key,
+    access_token_secret: settings.twitter.access_token_secret,
+  });
+  return done();
+};
+

--- a/js/server/plugins/twitter.js
+++ b/js/server/plugins/twitter.js
@@ -123,7 +123,11 @@ Twitter.attach = function(options) {
                 res.end();
                 return;
               }
-              res.json({ status: 'ok', screen_name: results.screen_name });
+              res.json({
+                status: 'ok',
+                id: results.user_id,
+                screen_name: results.screen_name
+              });
             }
           );
         }

--- a/js/update.js
+++ b/js/update.js
@@ -1,0 +1,21 @@
+/**
+ * @fileoverview Updates poems by a given user.
+ */
+
+self.onmessage = function(event) {
+  // Update any existing poems by this user.
+  var req = new XMLHttpRequest();
+  var data = JSON.stringify({
+    id: event.data.id,
+    oldAuthor: event.data.oldAuthor,
+    newAuthor: event.data.newAuthor,
+  });
+  req.open('POST', event.data.callback, false);
+  req.setRequestHeader('Content-Type', 'application/json');
+  req.send(data);
+
+  if (req.status !== 200) {
+    self.postMessage(req.status);
+  }
+};
+


### PR DESCRIPTION
This branch handles twitter logins and updates a poem that was saved anonymously if that exists.

To test this (which someone else besides me NEEDS to do before I'm comfortable merging this ;)):
- Go to magpo
- Create a new poem and save it
- Log in with twitter
- Confirm in the database that authorship has been updated
- Create a new session, go back to the poem you created and log in with twitter
- Make changes and save, confirm that you are not redirected to a new URL (i.e. it's letting you update versus forking).

There are other variations of this that should be tested too, but this is the big one.
