### PR TITLE
Fix for loading new poem from listings page.

### DIFF
--- a/js/magpo.js
+++ b/js/magpo.js
@@ -957,6 +957,13 @@
       }
     },
     loadPoem: function(e) {
+      // Redirect to a new poem if the id wasn't set and a poem has
+      // already been loaded.
+      if (!$(e.currentTarget).attr('data-id') && window.MagPo.app.poem.id) {
+        window.location = '/magpo/';
+        return;
+      }
+
       window.MagPo.app.router.navigate(
         $(e.currentTarget).attr('data-id'),
         { trigger: true }


### PR DESCRIPTION
Loading a new poem from the listings page was not working if you tapped/clicked the top list item after already loading a different poem. This change fixes that.
